### PR TITLE
Firewall Rules checking added as .bat

### DIFF
--- a/PinBoxServer/PinBoxServer/Check-Pinbox-Firewall-Rules.bat
+++ b/PinBoxServer/PinBoxServer/Check-Pinbox-Firewall-Rules.bat
@@ -1,0 +1,20 @@
+@echo off
+title = Pinbox Firewall Setup
+echo Checking PinBox Server executable...
+IF NOT EXIST %~dp0PinBoxServer.exe GOTO pinnotdetected
+echo PinBox Executable found!
+echo Elevating privilegies...
+if not "%1"=="am_admin" (powershell start -verb runas '%0' am_admin & exit /b)
+
+echo Admin detected.
+echo Adding rules...
+rem REMEMBER TO CHANGE THE PROGRAM NAME IF THE BINARY FILE NAME CHANGES
+netsh advfirewall firewall add rule name="PinboxOut" dir=out action=allow  profile=any program= "%~dp0PinBoxServer.exe" enable=yes
+netsh advfirewall firewall add rule name="PinBoxIn" dir=in action=allow  profile=any program= "%~dp0PinBoxServer.exe" enable=yes
+echo Done
+pause
+exit
+
+:pinnotdetected
+echo PinBoxServer.exe doesn't exists. Remember to run this script in THE SAME FOLDER AS THE EXECUTABLE.
+pause exit


### PR DESCRIPTION
The .bat file must be placed in the same folder as the PinBoxServer.exe and if it changes its name, the script must reflex it. It must be executed as admin privilegies and if the executable is not found, it will exit.